### PR TITLE
Update jar basename V4

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -55,6 +55,8 @@ android.libraryVariants.all { variant ->
         exclude '**/Manifest.class'
         exclude '**/Manifest\$*.class'
         exclude '**/BuildConfig.class'
+
+        baseName 'ParseFacebookUtilsV4'
     }
 
     def javadocTask = task("javadoc${variant.name.capitalize()}", type: Javadoc) {


### PR DESCRIPTION
Update jar base name, so when we run
```
./gradlew clean jarRelease
```
the compiled jar name is `ParseFacebookUtilsV4-VERSION.jar` not `library-VERSION.jar`